### PR TITLE
Changed "http_cache" directory location to default value

### DIFF
--- a/freeswitch/autoload_configs/http_cache.conf.xml
+++ b/freeswitch/autoload_configs/http_cache.conf.xml
@@ -1,7 +1,7 @@
 <configuration name="http_cache.conf" description="HTTP GET cache">
   <settings>
     <param name="max-urls" value="10000"/>
-    <param name="location" value="$${sounds_dir}/http_cache"/>
+    <param name="location" value="$${cache_dir}"/>
     <param name="default-max-age" value="86400"/>
     <param name="prefetch-thread-count" value="8"/>
     <param name="prefetch-queue-size" value="100"/>


### PR DESCRIPTION
If /usr partition is mounted in read only mode on current master is not possible to use `http_cache` module.
Now will be used  default `/var/cache/freeswitch` on CentOS