### PR TITLE
Explicitly set CA bundle for http_cache

### DIFF
--- a/freeswitch/autoload_configs/http_cache.conf.xml
+++ b/freeswitch/autoload_configs/http_cache.conf.xml
@@ -5,5 +5,6 @@
     <param name="default-max-age" value="86400"/>
     <param name="prefetch-thread-count" value="8"/>
     <param name="prefetch-queue-size" value="100"/>
+    <param name="ssl-cacert" value="/etc/pki/tls/certs/ca-bundle.crt"/>
   </settings>
 </configuration>


### PR DESCRIPTION
When downloading files from an AWS account, http_cache failed to
download them until this config param was added. Whatever
FreeSWITCH/mod_http_cache defaulted to wasn't/isn't working with AWS's certs.