### PR TITLE
Update systemd service to support RT prio and renice, fix logrotate

### DIFF
--- a/system/logrotate.d/freeswitch.conf
+++ b/system/logrotate.d/freeswitch.conf
@@ -5,6 +5,7 @@
     compress
     delaycompress
     sharedscripts
+    missingok
     postrotate
         /bin/kill -HUP `cat /var/run/freeswitch/freeswitch.pid 2> /dev/null` 2> /dev/null || true
     endscript

--- a/system/logrotate.d/freeswitch.conf.debian
+++ b/system/logrotate.d/freeswitch.conf.debian
@@ -1,0 +1,13 @@
+/var/log/freeswitch/*.log {
+    daily
+    rotate 31
+    nocreate
+    compress
+    delaycompress
+    sharedscripts
+    missingok
+    su freeswitch freeswitch
+    postrotate
+        /bin/kill -HUP `cat /var/run/freeswitch/freeswitch.pid 2> /dev/null` 2> /dev/null || true
+    endscript
+}

--- a/system/systemd/kazoo-freeswitch.service
+++ b/system/systemd/kazoo-freeswitch.service
@@ -6,16 +6,23 @@ After=syslog.target network-online.target
 User=freeswitch
 Group=daemon
 PermissionsStartOnly=true
-LimitNOFILE=65536
 LimitCORE=infinity
-# RuntimeDirectory is not yet supported in CentOS 7. A workaround is to use /etc/tmpfiles.d/freeswitch.conf
-# RuntimeDirectory=/run/freeswitch
-# RuntimeDirectoryMode=0750
+LimitNOFILE=100000
+LimitNPROC=60000
+LimitSTACK=250000
+LimitRTPRIO=infinity
+LimitRTTIME=infinity
+IOSchedulingClass=realtime
+IOSchedulingPriority=2
+CPUSchedulingPolicy=rr
+CPUSchedulingPriority=89
+UMask=0007
+ExecStartPre=setcap 'cap_net_bind_service,cap_sys_nice=+ep' /usr/bin/freeswitch
 ExecStartPre=/usr/sbin/kazoo-freeswitch prepare
 ExecStart=/usr/sbin/kazoo-freeswitch start -nc -nf
 ExecReload=/usr/bin/kill -HUP $MAINPID
 Restart=on-abort
-PIDFile=/var/run/freeswitch/freeswitch.pid
+PIDFile=/run/freeswitch/freeswitch.pid
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- The current `kazoo-freeswitch.service` does not allow freeswitch to assume real-time priority or to renice. This PR incorporates upstream changes to allow this.

- The logrotate config causes a systemd error to be logged when it starts and there are no log files present. This PR adds `missingok` to prevent this error.

- The Debian version of `freeswitch` runs with user and group `freeswitch`. This causes problems with log rotation, so this PR adds a `freeswitch.conf.debian` that adds `su freeswitch freeswitch` to prevent that.