### PR TITLE
Set certs dir in FS command line args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *~
 freeswitch.serial
-
+freeswitch/certs/*

--- a/system/sbin/kazoo-freeswitch
+++ b/system/sbin/kazoo-freeswitch
@@ -16,7 +16,7 @@ CFG_FILE=${FS_CONFIG:-/etc/kazoo/freeswitch}
 export HOME=${FS_HOME:-/var/lib/kazoo-freeswitch}
 
 if [ -z "${FREESWITCH_ARGS}" ]; then
-	FREESWITCH_ARGS="-nonat -conf ${CFG_FILE} -run /var/run/freeswitch -db /var/lib/kazoo-freeswitch/db -log /var/log/freeswitch -cache /var/lib/kazoo-freeswitch/cache -sounds /usr/share/kazoo-freeswitch/sounds -storage /var/lib/kazoo-freeswitch/storage"
+	FREESWITCH_ARGS="-nonat -conf ${CFG_FILE} -run /var/run/freeswitch -certs /etc/kazoo/freeswitch/certs -db /var/lib/kazoo-freeswitch/db -log /var/log/freeswitch -cache /var/lib/kazoo-freeswitch/cache -sounds /usr/share/kazoo-freeswitch/sounds -storage /var/lib/kazoo-freeswitch/storage"
 fi
 
 prepare() {


### PR DESCRIPTION
Certs dir defaults to /etc/freeswitch/tls but let's put them in the directory designated for certs in the configs repo (/etc/kazoo/freeswitch/certs)

Let me know if this should also be applied to 5.x