### PR TITLE
Extended receive-timeout from 1ms to 200ms. 

### DIFF
--- a/freeswitch/autoload_configs/kazoo.conf.xml
+++ b/freeswitch/autoload_configs/kazoo.conf.xml
@@ -10,7 +10,7 @@
         <param name="event-stream-preallocate" value="32768"/>
         <param name="receive-msg-preallocate" value="32768"/>
         <param name="node-worker-threads" value="5"/>
-        <param name="receive-timeout" value="1"/>
+        <param name="receive-timeout" value="200"/>
         <param name="event-stream-framing" value="4"/>
     </settings>
 </configuration>


### PR DESCRIPTION
This value was too small resulting in messages being dropped by mod_kazoo's erlang message
receiver during high load. 200 is the default value set in mod_kazoo if the value is not defined in the config file.