### PR TITLE
use AmbientCapabilities in systemd

### DIFF
--- a/.shipyard.yml
+++ b/.shipyard.yml
@@ -46,10 +46,6 @@ package:
 
       mkdir -p %{buildroot}/usr/lib/systemd/system
       cp system/systemd/* %{buildroot}/usr/lib/systemd/system
-    post: |
-        if [ -x "/usr/bin/freeswitch" ]; then
-            setcap 'cap_net_bind_service,cap_sys_nice=+ep' /usr/bin/freeswitch
-        fi
     files:
       doc:
         - CHANGELOG

--- a/system/systemd/kazoo-freeswitch.service
+++ b/system/systemd/kazoo-freeswitch.service
@@ -3,6 +3,7 @@ Description=FreeSWITCH Configured for Kazoo
 After=syslog.target network-online.target
 
 [Service]
+AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_SYS_NICE
 User=freeswitch
 Group=daemon
 PermissionsStartOnly=true


### PR DESCRIPTION
* when installing kazoo-freeeswitch in a docker environment
  using setcap on the executable makes it unusable

(cherry picked from commit 798aa5d501a0b8ecafb0f800ac475c1dfe4e1506)