### PR TITLE
KZOO-322 Attended Transfers Not Updating Caller ID

### DIFF
--- a/freeswitch/vars/defaults.xml
+++ b/freeswitch/vars/defaults.xml
@@ -4,6 +4,7 @@
     <X-PRE-PROCESS cmd="set" data="hold_music=local_stream://default"/>
     
     <X-PRE-PROCESS cmd="set" data="ignore_display_updates=false"/>
+    <X-PRE-PROCESS cmd="set" data="update_ignore_ua=true"/>
     <X-PRE-PROCESS cmd="set" data="recordings_dir=/tmp/"/>
     <X-PRE-PROCESS cmd="set" data="send_silence_when_idle=-1"/>
 

--- a/freeswitch/vars/defaults.xml
+++ b/freeswitch/vars/defaults.xml
@@ -1,10 +1,8 @@
 <include>
     <X-PRE-PROCESS cmd="set" data="disable_system_api_commands=true"/>
-    
+
     <X-PRE-PROCESS cmd="set" data="hold_music=local_stream://default"/>
-    
-    <X-PRE-PROCESS cmd="set" data="ignore_display_updates=false"/>
-    <X-PRE-PROCESS cmd="set" data="update_ignore_ua=true"/>
+
     <X-PRE-PROCESS cmd="set" data="recordings_dir=/tmp/"/>
     <X-PRE-PROCESS cmd="set" data="send_silence_when_idle=-1"/>
 

--- a/freeswitch/vars/display-updates.xml
+++ b/freeswitch/vars/display-updates.xml
@@ -1,0 +1,6 @@
+<include>
+
+    <X-PRE-PROCESS cmd="set" data="ignore_display_updates=false"/>
+    <X-PRE-PROCESS cmd="set" data="update_ignore_ua=true"/>
+
+</include>


### PR DESCRIPTION
This PR doesn’t solve problem for all UAs, however the new variable update_ignore_ua can extend range of clients which will receive display updates. For more satisfying solution targeting more UAs we would have to implement different method - people with similar problem suggest re-INVITE with Replaces. 