### PR TITLE
[5.3] FREE-86 : As an admin I want the default UA ignore updates configuration to support PolyEdge

### DIFF
--- a/freeswitch/vars/display-updates.xml
+++ b/freeswitch/vars/display-updates.xml
@@ -83,7 +83,7 @@
 
     -->
     <!--X-PRE-PROCESS cmd="set" data="update_ignore_ua=false"/-->
-    <!--X-PRE-PROCESS cmd="set" data="update_ignore_ua_regex=ua1|ua2"/-->
+    <X-PRE-PROCESS cmd="set" data="update_ignore_ua_regex=polyedge"/>
     <!--X-PRE-PROCESS cmd="set" data="update_ignore_ua_exceptions_regex=ua1|ua2"/>
 
 </include>


### PR DESCRIPTION
Set `update_ignore_ua` to true for `PolyEdge` devices. If `update_ignore_ua` is `false`, this will set `update_ignore_ua` to `true` for `PolyEdge` devices specifically.